### PR TITLE
Python agent with openjdk11-jre

### DIFF
--- a/python/python3/Dockerfile
+++ b/python/python3/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/inbound-agent:alpine as jnlp
 
 FROM python:alpine
 
-RUN apk -U add openjdk8-jre
+RUN apk -U add openjdk11-jre
 
 COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar


### PR DESCRIPTION
The docker image latest version for the python jnlp agent doesn't seem to run any more: https://github.com/jenkinsci/docker-inbound-agents/issues/32 
upgrading to jdk11 solves the issue for us on Jenkins 2.346.1

Thank you