### PR TITLE
Add buildx plugin to docker agent

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,23 @@ USER root
 
 # Alpine seems to come with libcurl baked in, which is prone to mismatching
 # with newer versions of curl. The solution is to upgrade libcurl.
-RUN apk update && apk add -u libcurl curl
+RUN apk add --no-cache -u libcurl curl
 # Install Docker client
 ARG DOCKER_VERSION=24.0.6
 ARG DOCKER_COMPOSE_VERSION=1.21.0
+ARG DOCKER_BUILDX_VERSION=0.11.2
 RUN curl -fsSL https://download.docker.com/linux/static/stable/`uname -m`/docker-$DOCKER_VERSION.tgz | tar --strip-components=1 -xz -C /usr/local/bin docker/docker
 RUN curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
+
+# Enable buildx plugin
+## buildx is released as amd64, and uname calls it x86_64
+RUN uname -m > /tmp/arch \
+    && sed -i 's/x86_64/amd64/g' /tmp/arch \
+    && mkdir -p /usr/libexec/docker/cli-plugins/  \
+    && curl -fsSL https://github.com/docker/buildx/releases/download/v$DOCKER_BUILDX_VERSION/buildx-v0.11.2.linux-`cat /tmp/arch` > /usr/libexec/docker/cli-plugins/docker-buildx  \
+    && chmod +x /usr/libexec/docker/cli-plugins/docker-buildx \
+    && docker buildx install \
+    && rm /tmp/arch
 
 RUN touch /debug-flag
 USER jenkins

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache -u libcurl curl
 # Install Docker client
 ARG DOCKER_VERSION=24.0.6
 ARG DOCKER_COMPOSE_VERSION=1.21.0
-ARG DOCKER_BUILDX_VERSION=0.11.2
+ARG DOCKER_BUILDX_VERSION=0.16.0
 RUN curl -fsSL https://download.docker.com/linux/static/stable/`uname -m`/docker-$DOCKER_VERSION.tgz | tar --strip-components=1 -xz -C /usr/local/bin docker/docker
 RUN curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPO
 RUN uname -m > /tmp/arch \
     && sed -i 's/x86_64/amd64/g' /tmp/arch \
     && mkdir -p /usr/libexec/docker/cli-plugins/  \
-    && curl -fsSL https://github.com/docker/buildx/releases/download/v$DOCKER_BUILDX_VERSION/buildx-v0.11.2.linux-`cat /tmp/arch` > /usr/libexec/docker/cli-plugins/docker-buildx  \
+    && curl -fsSL https://github.com/docker/buildx/releases/download/v$DOCKER_BUILDX_VERSION/buildx-v$DOCKER_BUILDX_VERSION.linux-`cat /tmp/arch` > /usr/libexec/docker/cli-plugins/docker-buildx  \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-buildx \
     && docker buildx install \
     && rm /tmp/arch


### PR DESCRIPTION
Docker 24.0.6 comes with new build API as default when installed with distro packages (`apt`, `apk`, `yum`). Binary installation has no buildx plugin.

This change adds installation script and enables buildx as a default API.

Additionally This change includes minor optimisation of `apk` usage, which reduces the image size.

### Testing done
1. `docker build . -t docker-agent && docker run -v /var/run/docker.sock:/var/run/docker.sock -it --entrypoint /bin/bash docker-agent`
    * `docker version`
    * `docker ps`
    * `echo $DOCKERFILE_CONTENT > Dockerfile && docker build .`
2. Running it with Jenkins as a agent with docker:dind and with mounted host's docker socket.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
