### PR TITLE
Add Git to Python images

### DIFF
--- a/python/python2/Dockerfile
+++ b/python/python2/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/inbound-agent:alpine as jnlp
 
 FROM python:2-alpine
 
-RUN apk -U add openjdk11-jre
+RUN apk -U add openjdk11-jre git
 
 COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar

--- a/python/python3/Dockerfile
+++ b/python/python3/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/inbound-agent:alpine as jnlp
 
 FROM python:alpine
 
-RUN apk -U add openjdk11-jre
+RUN apk -U add openjdk11-jre git
 
 COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar


### PR DESCRIPTION
It would be very convenient if jnlp-agent-python images had git as well as now in jnlp-agent-ruby.